### PR TITLE
findByidメソッドの単体テストコードの実装

### DIFF
--- a/src/main/java/com/example/name/entity/Name.java
+++ b/src/main/java/com/example/name/entity/Name.java
@@ -39,4 +39,17 @@ public class Name {
     public void setAge(int age) {
         this.age = age;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Name name = (Name) o;
+        return age == name.age && Objects.equals(id, name.id) && Objects.equals(this.name, name.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, age);
+    }
 }

--- a/src/test/java/com/example/name/service/NameServiceTest.java
+++ b/src/test/java/com/example/name/service/NameServiceTest.java
@@ -1,0 +1,44 @@
+package com.example.name.service;
+
+
+import com.example.name.entity.Name;
+import com.example.name.exception.ResourceNotFoundException;
+import com.example.name.mapper.NameMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class NameServiceTest {
+
+    @InjectMocks
+    NameService nameService;
+
+    @Mock
+    NameMapper nameMapper;
+
+    @Test
+    public void 存在するユーザーのIDを指定したときに正常にユーザーが返されること() {
+        doReturn(Optional.of(new Name(1, "yuki", 29))).when(nameMapper).findById(1);
+        Name actual = nameService.findById(1);
+        assertThat(actual).isEqualTo(new Name(1, "yuki", 29));
+        verify(nameMapper).findById(1);
+    }
+
+    @Test
+    public void 存在しないユーザーのIDを指定したときにエラーが返されること() {
+        doReturn(Optional.empty()).when(nameMapper).findById(10);
+        assertThrows(ResourceNotFoundException.class, () -> {
+            nameService.findById(10);
+        });
+    }
+}

--- a/src/test/java/com/example/name/service/NameServiceTest.java
+++ b/src/test/java/com/example/name/service/NameServiceTest.java
@@ -12,7 +12,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static com.jayway.jsonpath.internal.path.PathCompiler.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -40,5 +42,14 @@ public class NameServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             nameService.findById(10);
         });
+    }
+
+    @Test
+    public void 存在しないユーザーのIDを指定したときに正しいエラーメッセージが返されること() {
+        doReturn(Optional.empty()).when(nameMapper).findById(10);
+        Throwable exception = assertThrows(ResourceNotFoundException.class, () -> {
+            nameService.findById(10);
+        });
+        assertEquals("指定されたIDの名前は存在しません", exception.getMessage());
     }
 }


### PR DESCRIPTION
## 概要
NameServiceのfindByIdメソッドの単体テストコードの実装

### 実装内容
１ Name.javaクラスにequalsメソッドとhashCodeメソッドを実装
２ NameServiceTestクラスを新しく作り、findByIdメソッドの単体テストコードを実装

## 動作確認
【存在するユーザーのIDを指定したときに正常にユーザーが返されること】
![image](https://github.com/yuuksibunta/Final-Assignment/assets/148073110/03681e59-d367-49f3-b16a-db6f55a89d03)

【 存在しないユーザーのIDを指定したときにエラーが返されること】
![image](https://github.com/yuuksibunta/Final-Assignment/assets/148073110/cb0385b9-08b7-4dd9-ab38-901a99cb749d)
