### PR TITLE
insertメソッドの単体テストコードを実装

### DIFF
--- a/src/main/java/com/example/name/controller/NameRequest.java
+++ b/src/main/java/com/example/name/controller/NameRequest.java
@@ -3,6 +3,8 @@ package com.example.name.controller;
 import com.example.name.entity.Name;
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.Objects;
+
 public class NameRequest {
     @NotBlank(message = "必須フィールドです")
     private String name;
@@ -37,5 +39,19 @@ public class NameRequest {
     public boolean isValid() {
 
         return name != null && !name.trim().isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NameRequest that = (NameRequest) o;
+        return age == that.age &&
+                Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, age);
     }
 }

--- a/src/test/java/com/example/name/service/NameServiceTest.java
+++ b/src/test/java/com/example/name/service/NameServiceTest.java
@@ -1,6 +1,8 @@
 package com.example.name.service;
 
+import com.example.name.controller.NameRequest;
 import com.example.name.entity.Name;
+import com.example.name.exception.NameBadRequestException;
 import com.example.name.exception.NameNotFoundException;
 import com.example.name.mapper.NameMapper;
 
@@ -15,8 +17,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class NameServiceTest {
@@ -50,5 +52,29 @@ public class NameServiceTest {
             nameService.findById(10);
         });
         assertEquals("指定されたIDの名前は存在しません", exception.getMessage());
+    }
+
+    @Test
+    public void 正常に新規のユーザーが登録できること() {
+        NameRequest newNameRequest = new NameRequest("kazushi", 33);
+        doNothing().when(nameMapper).insert(any(Name.class));
+        nameService.insert(newNameRequest);
+        verify(nameMapper).insert(any(Name.class));
+    }
+
+    @Test
+    public void 登録に必要なデータが不足している場合はエラーが返されること() {
+        assertThrows(NameBadRequestException.class, () -> nameService.insert(new NameRequest("", 33)));
+        assertThrows(NameBadRequestException.class, () -> nameService.insert(new NameRequest("kazushi", null)));
+        assertThrows(NameBadRequestException.class, () -> nameService.insert(new NameRequest("", null)));
+    }
+
+    @Test
+    public void 登録に必要なデータが不足している場合は正しいエラーメッセージが返されること() {
+        NameRequest nameRequest = new NameRequest("", null);
+        NameBadRequestException exception = assertThrows(NameBadRequestException.class, () -> {
+            nameService.insert(nameRequest);
+        });
+        assertEquals("必須フィールドが入力されていません", exception.getMessage());
     }
 }

--- a/src/test/java/com/example/name/service/NameServiceTest.java
+++ b/src/test/java/com/example/name/service/NameServiceTest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
@@ -60,9 +59,9 @@ public class NameServiceTest {
     @Test
     public void 正常に新規のユーザーが登録できること() {
         NameRequest newNameRequest = new NameRequest("kazushi", 33);
-        Mockito.doNothing().when(nameMapper).insert(any(Name.class));
+        Mockito.doNothing().when(nameMapper).insert(newNameRequest.convertToName());
         nameService.insert(newNameRequest);
-        verify(nameMapper).insert(any(Name.class));
+        verify(nameMapper).insert(newNameRequest.convertToName());
     }
 
     @Test

--- a/src/test/java/com/example/name/service/NameServiceTest.java
+++ b/src/test/java/com/example/name/service/NameServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -18,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
 
 @ExtendWith(MockitoExtension.class)
 public class NameServiceTest {
@@ -57,7 +60,7 @@ public class NameServiceTest {
     @Test
     public void 正常に新規のユーザーが登録できること() {
         NameRequest newNameRequest = new NameRequest("kazushi", 33);
-        doNothing().when(nameMapper).insert(any(Name.class));
+        Mockito.doNothing().when(nameMapper).insert(any(Name.class));
         nameService.insert(newNameRequest);
         verify(nameMapper).insert(any(Name.class));
     }


### PR DESCRIPTION
## 概要
・Serviceクラスのinsertメソッドの単体テストコードの実装

## 実装内容
・正常に新規のデータが登録できるかを検証
・登録に必要なデータが不足している場合はエラーを返すことを検証
・登録に必要なデータが不足している場合は正しいエラーメッセージを返すことを検証

## 動作確認

１．正常に新規のデータが登録できるかを検証
![image](https://github.com/yuuksibunta/Final-Assignment/assets/148073110/4ddbb4d7-359f-4d03-a269-8a74c346f285)

２．登録に必要なデータが不足している場合はエラーを返すことを検証
※名前のみが不足の場合、年齢のみが不足の場合、名前と年齢の両方が不足の場合の３つの場合を検証
![image](https://github.com/yuuksibunta/Final-Assignment/assets/148073110/22f01237-a020-48a9-9a08-cb8851085369)

３．登録に必要なデータが不足している場合は正しいエラーメッセージを返すことを検証
![image](https://github.com/yuuksibunta/Final-Assignment/assets/148073110/90f2ff5c-fff2-4386-9a6e-95a79e6173c6)
